### PR TITLE
fix a typo on install.sh

### DIFF
--- a/InstallCDT/install.sh
+++ b/InstallCDT/install.sh
@@ -93,7 +93,7 @@ fi
 if [ -w /Library/Application\ Support/Developer/Shared/Xcode/Specifications ];then
 	/bin/echo "Permissions properly set up, continuing install."
 else
-	/bin/echo "For this script to complete successfully, the directory /Library/Application Support/Develper/Shared/Xcode/Specifications must be writeable by you, and we've detected that it isn't.  "
+	/bin/echo "For this script to complete successfully, the directory /Library/Application Support/Developer/Shared/Xcode/Specifications must be writeable by you, and we've detected that it isn't.  "
 	exit 1
 fi
 


### PR DESCRIPTION
The path in the message shown when "/Library/Application Support/Developer/Shared/Xcode/Specifications" isn't available is wrong.
